### PR TITLE
Minor refactoring of formatters

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
   maxWorkers: 2,
   moduleDirectories: ['node_modules'],
   moduleFileExtensions: ['js', 'json'],
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.js', '**/?(*.)+(spec|test).js']
 }

--- a/src/__tests__/intl.test.js
+++ b/src/__tests__/intl.test.js
@@ -1,0 +1,27 @@
+const { getActionTranslations } = require('../intl')
+
+describe('intl', () => {
+  describe('getActionTranslations', () => {
+    test('returns dict. of action name and tip according to current language', () => {
+      expect(getActionTranslations('addToFavorites', 'en')).toEqual({
+        action: '/add to favorites',
+        actionTip: 'to access favorites list enter "."'
+      })
+
+      expect(getActionTranslations('addToFavorites', 'ru')).toEqual({
+        action: '/добавить в избранное',
+        actionTip: 'получить доступ к списку избранного можно набрав "."'
+      })
+
+      expect(getActionTranslations('save', 'en')).toEqual({
+        action: '/save',
+        actionTip: 'save updated translation'
+      })
+
+      expect(getActionTranslations('save', 'ru')).toEqual({
+        action: '/сохранить',
+        actionTip: 'сохранит обновленный перевод'
+      })
+    })
+  })
+})

--- a/src/__tests__/output.test.js
+++ b/src/__tests__/output.test.js
@@ -1,0 +1,237 @@
+const { getTranslationSource } = require('../translation-direction')
+const {
+  formatMainTranslation,
+  formatOtherTranslations,
+  formatAutoCorrection,
+  formatLastSearch,
+  addToFavoritesAction
+} = require('../output')
+
+const getStrLanguage = getTranslationSource
+
+describe('output', () => {
+  describe('formatMainTranslation', () => {
+    test('prepares raw translation to alfy-output in format {title, subtitle}', () => {
+      // originalInput = 'castle'
+      const translation = 'замок'
+      const pronunciation = 'kasəl'
+      const targetLang = 'en'
+
+      const mainTranslation = formatMainTranslation(
+        translation,
+        pronunciation,
+        targetLang
+      )
+
+      expect(mainTranslation).toEqual({
+        title: 'замок [kasəl]',
+        subtitle: 'best fit translation'
+      })
+    })
+
+    describe('pronunciation', () => {
+      test('adds "pronunciation" next to translation if there is one', () => {
+        // originalInput = 'indeed'
+        const translation = 'верно'
+        const pronunciation = 'inˈdēd'
+        const targetLang = 'en'
+
+        const mainTranslation = formatMainTranslation(
+          translation,
+          pronunciation,
+          targetLang
+        )
+
+        expect(mainTranslation).toEqual({
+          title: 'верно [inˈdēd]',
+          subtitle: 'best fit translation'
+        })
+      })
+
+      test('returns only translation, if no pronunciation found', () => {
+        // originalInput = 'indeed'
+        const translation = 'верно'
+        const pronunciation = undefined
+        const targetLang = 'en'
+
+        const mainTranslation = formatMainTranslation(
+          translation,
+          pronunciation,
+          targetLang
+        )
+
+        expect(mainTranslation).toEqual({
+          title: 'верно',
+          subtitle: 'best fit translation'
+        })
+      })
+    })
+
+    describe('shows translation and tip in subtitle in "targetLang" and pronunciation in "sourceLang"', () => {
+      test('for en-ru direction', () => {
+        // originalInput = 'dwell'
+        const translation = 'жить'
+        const pronunciation = 'dwell'
+        const targetLang = 'ru'
+
+        const mainTranslation = formatMainTranslation(
+          translation,
+          pronunciation,
+          targetLang
+        )
+        const hintLang = getStrLanguage(mainTranslation.subtitle)
+
+        expect(mainTranslation).toEqual({
+          title: 'жить [dwell]',
+          subtitle: 'найболее подходящий перевод'
+        })
+
+        expect(hintLang).toBe('ru')
+      })
+
+      test('for ru-en direction', () => {
+        // originalInput = 'обитать'
+        const translation = 'dwell'
+        const pronunciation = "obitat'"
+        const targetLang = 'en'
+
+        const mainTranslation = formatMainTranslation(
+          translation,
+          pronunciation,
+          targetLang
+        )
+        const hintLang = getStrLanguage(mainTranslation.subtitle)
+
+        expect(mainTranslation).toEqual({
+          title: "dwell [obitat']",
+          subtitle: 'best fit translation'
+        })
+
+        expect(hintLang).toBe('en')
+      })
+    })
+  })
+
+  describe('formatOtherTranslations', () => {
+    test('prepares other translations to alfy-output format of {title: translation}', () => {
+      const translations = [
+        'замок',
+        'дворец',
+        'ладья',
+        'твердыня',
+        'рокировка',
+        'убежище'
+      ]
+
+      const formattedOtherTranslations = formatOtherTranslations(translations)
+
+      expect(formattedOtherTranslations).toEqual([
+        {
+          title: 'дворец'
+        },
+        {
+          title: 'ладья'
+        },
+        {
+          title: 'твердыня'
+        },
+        {
+          title: 'рокировка'
+        },
+        {
+          title: 'убежище'
+        }
+      ])
+    })
+
+    test('not fails, when translations are empty', () => {
+      expect(formatOtherTranslations()).toEqual([])
+
+      expect(formatOtherTranslations([])).toEqual([])
+    })
+  })
+
+  describe('formatAutoCorrection', () => {
+    test('prepares auto corrected value to alfy-output format', () => {
+      // originalInput = 'casle'
+      const correctedValue = 'castle'
+      const targetLang = 'ru'
+
+      const autoCorrectedItem = formatAutoCorrection(correctedValue, targetLang)
+      const hintLang = getStrLanguage(autoCorrectedItem.subtitle)
+
+      expect(autoCorrectedItem).toEqual({
+        title: 'castle',
+        subtitle: 'возможно вы имели ввиду ⤴️',
+        autocomplete: 'castle',
+        icon: { path: './icons/question.png' }
+      })
+
+      expect(hintLang).toBe(targetLang)
+      expect(typeof autoCorrectedItem.icon.path).toBe('string')
+    })
+  })
+
+  describe('formatLastSearch', () => {
+    test('prepares last searched input to alfy-output format', () => {
+      const lastUserInput = 'dog'
+      const targetLang = 'ru'
+
+      const lastSearchItem = formatLastSearch(lastUserInput, targetLang)
+      const hintLang = getStrLanguage(lastSearchItem.subtitle)
+
+      expect(lastSearchItem).toEqual({
+        title: 'dog',
+        subtitle: 'предыдущий запрос',
+        icon: { path: './icons/history.png' }
+      })
+
+      expect(hintLang).toBe(targetLang)
+      expect(typeof lastSearchItem.icon.path).toBe('string')
+    })
+  })
+
+  describe('addToFavoritesAction', () => {
+    test('prepares addToFavs action to alfy-format, with proper arguments', () => {
+      const userInput = 'castle'
+      const translation = 'замок'
+      const otherTranslations = [
+        'замок',
+        'дворец',
+        'ладья',
+        'твердыня',
+        'рокировка',
+        'убежище'
+      ]
+      const targetLang = 'ru'
+
+      const addToFavsItem = addToFavoritesAction(
+        userInput,
+        translation,
+        otherTranslations,
+        targetLang
+      )
+      const titleLang = getStrLanguage(addToFavsItem.title)
+      const hintLang = getStrLanguage(addToFavsItem.subtitle)
+      const otherTranslationsInArg = /"translations":"(.*)"/gi.exec(
+        addToFavsItem.arg
+      )[1]
+      console.log('otherTranslationsInArg', otherTranslationsInArg)
+
+      expect(addToFavsItem).toEqual({
+        title: '/добавить в избранное',
+        subtitle: 'получить доступ к списку избранного можно набрав "."',
+        icon: { path: './icons/bookmark.png' },
+        arg:
+          '{"alfredworkflow":{"variables":{"action":"add","word":"castle","translations":"замок, дворец, ладья, твердыня, рокировка, убежище"}}}'
+      })
+
+      expect(titleLang).toBe(targetLang)
+      expect(hintLang).toBe(targetLang)
+      expect(typeof addToFavsItem.icon.path).toBe('string')
+      expect(otherTranslations.join(', ')).toEqual(otherTranslationsInArg)
+    })
+
+    // TODO: add test cases for 1 otherTranslations and 0 otherTranslations
+  })
+})

--- a/src/__tests__/rawGTranslateRes.mock.js
+++ b/src/__tests__/rawGTranslateRes.mock.js
@@ -1,0 +1,143 @@
+exports.responseMock = {
+  text: 'замок',
+  pronunciation: 'zamok',
+  from: {
+    language: {
+      didYouMean: false,
+      iso: 'en'
+    },
+    text: {
+      autoCorrected: false,
+      value: '',
+      didYouMean: false
+    }
+  },
+  raw: [
+    ['ˈkasəl', null, null, [[[0, [[[null, 6]], [true]]]], 6]],
+    [
+      [
+        [
+          null,
+          'zamok',
+          null,
+          null,
+          null,
+          [['замок', null, null, null, [['замок', [4, 5, 1]]]]]
+        ]
+      ],
+      'ru',
+      1,
+      'en',
+      ['castle', 'en', 'ru', true]
+    ],
+    null,
+    [
+      'castle',
+      [
+        [
+          [
+            'noun',
+            [
+              [
+                'a large building, typically of the medieval period, fortified against attack with thick walls, battlements, towers, and in many cases a moat.',
+                'Edinburgh Castle',
+                true,
+                null,
+                null,
+                [
+                  [
+                    [
+                      ['fortress'],
+                      ['fort'],
+                      ['stronghold'],
+                      ['fortification'],
+                      ['keep'],
+                      ['citadel'],
+                      ['fastness'],
+                      ['tower'],
+                      ['peel'],
+                      ['palace'],
+                      ['chateau'],
+                      ['donjon'],
+                      ['alcazar']
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            'verb',
+            [
+              [
+                'make a special move (no more than once in a game by each player) in which the king is transferred from its original square two squares along the back rank toward a rook on its corner square which is then transferred to the square passed over by the king.',
+                'both of the players castled on the queenside',
+                true
+              ]
+            ],
+            [['Chess']]
+          ]
+        ],
+        2
+      ],
+      [[[null, 'the crumbling stonework of a ruined <b>castle</b>']], null, 1],
+      null,
+      null,
+      [
+        [
+          [
+            'noun',
+            [
+              [
+                'замок',
+                null,
+                ['castle', 'lock', 'chateau', 'lock-hospital'],
+                1,
+                true
+              ],
+              [
+                'дворец',
+                null,
+                ['palace', 'castle', 'mansion', 'chateau', 'mansion house'],
+                2,
+                true
+              ],
+              ['ладья', null, ['rook', 'castle', 'shallop', 'ferry'], 3, true],
+              [
+                'твердыня',
+                null,
+                ['stronghold', 'citadel', 'castle', 'fastness'],
+                3,
+                true
+              ],
+              ['рокировка', null, ['castling', 'castle'], 3, true],
+              [
+                'убежище',
+                null,
+                ['asylum', 'refuge', 'shelter', 'haven', 'sanctuary', 'castle'],
+                3,
+                true
+              ]
+            ],
+            'ru',
+            'en'
+          ],
+          [
+            'verb',
+            [
+              ['рокировать', null, ['castle'], 3, true],
+              ['рокироваться', null, ['castle'], 3, true]
+            ],
+            'ru',
+            'en'
+          ]
+        ],
+        8
+      ],
+      null,
+      null,
+      'en',
+      1
+    ]
+  ]
+}

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,4 +1,10 @@
-const { createArgWithAction, createArgWithParams } = require('../utils.js')
+const {
+  parseAutoCorrection,
+  parseRawResponse,
+  createArgWithAction,
+  createArgWithParams
+} = require('../utils.js')
+const { responseMock } = require('./rawGTranslateRes.mock')
 
 const setup = variables => ({
   alfredworkflow: {
@@ -6,28 +12,71 @@ const setup = variables => ({
   }
 })
 
-test('createArgWithAction: properly convert workflow variables into string', () => {
-  expect(createArgWithAction('import')).toBe(
-    `{"alfredworkflow":{"variables":{"action":"import"}}}`
-  )
+describe('utils', () => {
+  test('parseAutoCorrection: returns whether translation was auto corrected', () => {
+    const translationDetails = {
+      language: { didYouMean: false, iso: 'en' },
+      text: { autoCorrected: false, value: '[castle]', didYouMean: true }
+    }
 
-  const workflow = setup({ action: 'import' })
+    expect(parseAutoCorrection(translationDetails)).toEqual({
+      isAutoCorrected: true,
+      correctedValue: 'castle'
+    })
+  })
 
-  expect(JSON.stringify(workflow)).toBe(createArgWithAction('import'))
-})
+  test('parseRawResponse: does initial data normalization of raw g-translate response', () => {
+    expect(parseRawResponse(responseMock.raw)).toMatchInlineSnapshot(
+      {
+        otherTranslations: [
+          'замок',
+          'дворец',
+          'ладья',
+          'твердыня',
+          'рокировка',
+          'убежище'
+        ],
+        pronunciation: 'ˈkasəl'
+      },
+      `
+      Object {
+        "otherTranslations": Array [
+          "замок",
+          "дворец",
+          "ладья",
+          "твердыня",
+          "рокировка",
+          "убежище",
+        ],
+        "pronunciation": "ˈkasəl",
+      }
+    `
+    )
+  })
 
-test('createArgWithParams: properly convert workflow variables into string', () => {
-  const action = 'remove or edit'
-  const word = 'embrace'
-  const translations = 'охватывать, обнимать'
+  test('createArgWithAction: properly convert workflow variables into string', () => {
+    expect(createArgWithAction('import')).toBe(
+      `{"alfredworkflow":{"variables":{"action":"import"}}}`
+    )
 
-  expect(createArgWithParams(action, word, translations)).toBe(
-    `{"alfredworkflow":{"variables":{"action":"${action}","word":"${word}","translations":"${translations}"}}}`
-  )
+    const workflow = setup({ action: 'import' })
 
-  const workflow = setup({ action, word, translations })
+    expect(JSON.stringify(workflow)).toBe(createArgWithAction('import'))
+  })
 
-  expect(JSON.stringify(workflow)).toBe(
-    createArgWithParams(action, word, translations)
-  )
+  test('createArgWithParams: properly convert workflow variables into string', () => {
+    const action = 'remove or edit'
+    const word = 'embrace'
+    const translations = 'охватывать, обнимать'
+
+    expect(createArgWithParams(action, word, translations)).toBe(
+      `{"alfredworkflow":{"variables":{"action":"${action}","word":"${word}","translations":"${translations}"}}}`
+    )
+
+    const workflow = setup({ action, word, translations })
+
+    expect(JSON.stringify(workflow)).toBe(
+      createArgWithParams(action, word, translations)
+    )
+  })
 })

--- a/src/get-last-search-results.js
+++ b/src/get-last-search-results.js
@@ -2,6 +2,7 @@ const { lastSearchCache } = require('./cache/last-search-cache.js')
 const { formatLastSearch } = require('./output.js')
 
 exports.getLastSearchResults = () => {
+  // NOTE, @genechulkov: here prevDestLang should be prevTargetLang
   const { prevUserInput, prevOutput = [], prevDestLang } = lastSearchCache.get()
 
   const lastSearch = formatLastSearch(prevUserInput, prevDestLang)

--- a/src/output.js
+++ b/src/output.js
@@ -4,6 +4,24 @@ const { intl, getActionTranslations } = require('./intl')
 const { createArgWithParams } = require('./utils')
 const { favoritesOperations } = require('./const')
 
+function pickBestTranslations(otherTranslations, translation) {
+  let bestTranslations
+  if (otherTranslations?.length > 1) {
+    const concatenatedMultipleTransl = otherTranslations.join(', ')
+    bestTranslations = concatenatedMultipleTransl
+  } else if (otherTranslations?.length === 1) {
+    const firstTranslation = get(otherTranslations, '0')
+    bestTranslations = firstTranslation
+  } else {
+    bestTranslations = translation
+  }
+
+  return bestTranslations.toLowerCase()
+}
+
+// NOTE, @genechulkov, seems like this should be renamed
+// to smth. more "format" related, like
+// formatAddToFavsAction
 exports.addToFavoritesAction = (
   userInput,
   translation,
@@ -22,19 +40,8 @@ exports.addToFavoritesAction = (
     arg: createArgWithParams(
       favoritesOperations.ADD,
       userInput,
-      pickBestTranslations()
+      pickBestTranslations(otherTranslations, translation)
     )
-  }
-
-  function pickBestTranslations() {
-    if (otherTranslations?.length > 1) {
-      const concated = otherTranslations.join(', ').toLowerCase()
-      return concated
-    }
-
-    const firstTranslation = get(otherTranslations, '0') || ''
-
-    return firstTranslation.toLowerCase()
   }
 }
 
@@ -48,21 +55,17 @@ exports.formatOtherTranslations = (otherTranslations = []) =>
     title: translation
   }))
 
-exports.formatAutoCorrection = (correctedValue, targetLang) => {
-  const parsedValue = correctedValue.replace(/[\[\]]/g, '')
-
-  return {
-    title: parsedValue,
-    subtitle: intl.autoCorrectMsg[targetLang],
-    autocomplete: parsedValue,
-    icon: {
-      path: './icons/question.png'
-    }
+exports.formatAutoCorrection = (correctedValue, targetLang) => ({
+  title: correctedValue,
+  subtitle: intl.autoCorrectMsg[targetLang],
+  autocomplete: correctedValue,
+  icon: {
+    path: './icons/question.png'
   }
-}
+})
 
-exports.formatLastSearch = (lastUserInput, destLang) => ({
+exports.formatLastSearch = (lastUserInput, targetLang) => ({
   title: lastUserInput,
-  subtitle: intl.lastSearch[destLang],
+  subtitle: intl.lastSearch[targetLang],
   icon: { path: './icons/history.png' }
 })

--- a/src/translate/get-translations.js
+++ b/src/translate/get-translations.js
@@ -13,6 +13,7 @@ const getTranslations = userInput => {
       const translationsList = createTranslationsList(response, to, userInput)
       lastSearchCache.set({
         prevUserInput: userInput,
+        // ⤵️
         prevDestLang: to,
         prevOutput: translationsList
       })

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,13 @@
 const get = require('lodash.get')
 
+const parseCorrectedValue = value => {
+  if (typeof value === 'string') {
+    return value.replace(/\[|\]/gi, '')
+  }
+
+  return ''
+}
+
 exports.parseAutoCorrection = translationDetails => {
   const { autoCorrected, value, didYouMean } = get(
     translationDetails,
@@ -8,7 +16,7 @@ exports.parseAutoCorrection = translationDetails => {
   )
   return {
     isAutoCorrected: autoCorrected || didYouMean,
-    correctedValue: value
+    correctedValue: parseCorrectedValue(value)
   }
 }
 


### PR DESCRIPTION
### What was done:
* **fix**: `pickBestTranslations` now properly shows the option, when only `one` translation provided by API (previously it was just ' ')
* **move** normalizing of `auto corrected` value from `formatter` to `parser`
* **add**: more `tests` for `utils.js` and `output.js`