### PR TITLE
main translation update

### DIFF
--- a/src/__tests__/output.test.js
+++ b/src/__tests__/output.test.js
@@ -1,5 +1,6 @@
 const { getTranslationSource } = require('../translation-direction')
 const {
+  formatPronunciation,
   formatMainTranslation,
   formatOtherTranslations,
   formatAutoCorrection,
@@ -9,105 +10,96 @@ const {
 const getStrLanguage = getTranslationSource
 
 describe('output', () => {
-  describe('formatMainTranslation', () => {
-    test('prepares raw translation to alfy-output in format {title, subtitle}', () => {
-      // originalInput = 'castle'
-      const translation = 'замок'
+  describe.only('formatPronunciation', () => {
+    test('creates list item, that shows pronunciation if it is provided by API', () => {
+      // originalInput = 'castle', translation = 'замок'
       const pronunciation = 'kasəl'
-      const targetLang = 'en'
+      const targetLang = 'uk'
 
-      const mainTranslation = formatMainTranslation(
-        translation,
+      const requestedPhrasePronunciation = formatPronunciation(
         pronunciation,
         targetLang
       )
 
-      expect(mainTranslation).toEqual({
-        title: 'замок [kasəl]',
-        subtitle: 'best fit translation',
-        arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"замок","translations":""}}}',
+      expect(requestedPhrasePronunciation).toEqual({
+        title: "[kasəl]",
+        subtitle: "вимова слова/фрази із запиту",
+        arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"kasəl","translations":""}}}',
         mods: {
           shift: {
-            arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"замок","translations":""}}}',
+            arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"kasəl","translations":""}}}',
           },
         },
       })
     })
 
-    describe('pronunciation', () => {
-      test('adds "pronunciation" next to translation if there is one', () => {
-        // originalInput = 'indeed'
-        const translation = 'вірно'
-        const pronunciation = 'inˈdēd'
-        const targetLang = 'en'
+    // this usually happens, when multi words phrase provided
+    test('creates a list item mock, if pronunciation is not provided', () => {
+      // originalInput = 'white castle on the rock', translation = 'Білий замок на скелі'
+      const pronunciation = null
+      const targetLang = 'uk'
 
-        const mainTranslation = formatMainTranslation(
-          translation,
-          pronunciation,
-          targetLang
-        )
+      const requestedPhrasePronunciation = formatPronunciation(
+        pronunciation,
+        targetLang
+      )
 
-        expect(mainTranslation).toEqual({
-          title: 'вірно [inˈdēd]',
-          subtitle: 'best fit translation',
-          arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"вірно","translations":""}}}',
-          mods: {
-            shift: {
-              arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"вірно","translations":""}}}',
-            },
+      // in final list this item simply will be omitted!
+      expect(requestedPhrasePronunciation).toEqual({
+        title: "",
+        subtitle: "вимова слова/фрази із запиту",
+        arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"","translations":""}}}',
+        mods: {
+          shift: {
+            arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"","translations":""}}}',
           },
-        })
+        },
       })
+    })
+  })
 
-      test('returns only translation, if no pronunciation found', () => {
-        // originalInput = 'indeed'
-        const translation = 'вірно'
-        const pronunciation = undefined
-        const targetLang = 'en'
+  describe('formatMainTranslation', () => {
+    test('prepares raw translation to alfy-output in format {title, subtitle}', () => {
+      // originalInput = 'castle'
+      const translation = 'замок'
+      const targetLang = 'uk'
 
-        const mainTranslation = formatMainTranslation(
-          translation,
-          pronunciation,
-          targetLang
-        )
+      const mainTranslation = formatMainTranslation(translation, targetLang)
 
-        expect(mainTranslation).toEqual({
-          title: 'вірно',
-          subtitle: 'best fit translation',
-          arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"вірно","translations":""}}}',
-          mods: {
-            shift: {
-              arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"вірно","translations":""}}}',
-            },
-          },
-        })
+      expect(mainTranslation).toEqual({
+        title: 'замок',
+        subtitle: 'накрайщий переклад',
+        arg:
+          '{"alfredworkflow":{"variables":{"action":"copy","word":"замок","translations":""}}}',
+        mods: {
+          shift: {
+            arg:
+              '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"замок","translations":""}}}'
+          }
+        }
       })
     })
 
-    describe('shows translation and tip in subtitle in "targetLang" and pronunciation in "sourceLang"', () => {
+    describe('shows translation and tip in subtitle in "targetLang"', () => {
       test('for en-uk direction', () => {
         // originalInput = 'dwell'
         const translation = 'мешкати'
-        const pronunciation = 'dwell'
         const targetLang = 'uk'
 
-        const mainTranslation = formatMainTranslation(
-          translation,
-          pronunciation,
-          targetLang
-        )
+        const mainTranslation = formatMainTranslation(translation, targetLang)
         const hintLang = getStrLanguage(mainTranslation.subtitle)
 
         expect(mainTranslation).toEqual({
-          title: 'мешкати [dwell]',
+          title: 'мешкати',
           subtitle: 'накрайщий переклад',
-          arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"мешкати","translations":""}}}',
+          arg:
+            '{"alfredworkflow":{"variables":{"action":"copy","word":"мешкати","translations":""}}}',
           mods: {
             shift: {
-              arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"мешкати","translations":""}}}'
-            },
-          },
-
+              arg:
+                '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"мешкати","translations":""}}}'
+            }
+          }
         })
 
         expect(hintLang).toBe('uk')
@@ -116,25 +108,25 @@ describe('output', () => {
       test('for uk-en direction', () => {
         // originalInput = 'мешкати'
         const translation = 'dwell'
-        const pronunciation = 'meshkaty'
         const targetLang = 'en'
 
         const mainTranslation = formatMainTranslation(
           translation,
-          pronunciation,
           targetLang
         )
         const hintLang = getStrLanguage(mainTranslation.subtitle)
 
         expect(mainTranslation).toEqual({
-          title: 'dwell [meshkaty]',
+          title: 'dwell',
           subtitle: 'best fit translation',
-          arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"dwell","translations":""}}}',
+          arg:
+            '{"alfredworkflow":{"variables":{"action":"copy","word":"dwell","translations":""}}}',
           mods: {
             shift: {
-              arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"dwell","translations":""}}}',
-            },
-          },
+              arg:
+                '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"dwell","translations":""}}}'
+            }
+          }
         })
 
         expect(hintLang).toBe('en')
@@ -158,48 +150,58 @@ describe('output', () => {
       expect(formattedOtherTranslations).toEqual([
         {
           title: 'контейнер',
-          arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"контейнер","translations":""}}}',
+          arg:
+            '{"alfredworkflow":{"variables":{"action":"copy","word":"контейнер","translations":""}}}',
           mods: {
             shift: {
-              arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"контейнер","translations":""}}}',
-            },
-          },
+              arg:
+                '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"контейнер","translations":""}}}'
+            }
+          }
         },
         {
           title: 'сховище',
-          arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"сховище","translations":""}}}',
+          arg:
+            '{"alfredworkflow":{"variables":{"action":"copy","word":"сховище","translations":""}}}',
           mods: {
             shift: {
-              arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"сховище","translations":""}}}',
-            },
-          },
+              arg:
+                '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"сховище","translations":""}}}'
+            }
+          }
         },
         {
           title: 'палац',
-          arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"палац","translations":""}}}',
+          arg:
+            '{"alfredworkflow":{"variables":{"action":"copy","word":"палац","translations":""}}}',
           mods: {
             shift: {
-              arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"палац","translations":""}}}',
-            },
-          },
+              arg:
+                '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"палац","translations":""}}}'
+            }
+          }
         },
         {
           title: 'тура',
-          arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"тура","translations":""}}}',
+          arg:
+            '{"alfredworkflow":{"variables":{"action":"copy","word":"тура","translations":""}}}',
           mods: {
             shift: {
-              arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"тура","translations":""}}}',
-            },
-          },
+              arg:
+                '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"тура","translations":""}}}'
+            }
+          }
         },
         {
           title: 'фортеця',
-          arg: '{"alfredworkflow":{"variables":{"action":"copy","word":"фортеця","translations":""}}}',
+          arg:
+            '{"alfredworkflow":{"variables":{"action":"copy","word":"фортеця","translations":""}}}',
           mods: {
             shift: {
-              arg: '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"фортеця","translations":""}}}',
-            },
-          },
+              arg:
+                '{"alfredworkflow":{"variables":{"action":"paste to foremost","word":"фортеця","translations":""}}}'
+            }
+          }
         }
       ])
     })

--- a/src/intl.js
+++ b/src/intl.js
@@ -1,4 +1,8 @@
 const intl = {
+  pronunciationMsg: {
+    uk: 'вимова слова/фрази із запиту',
+    en: 'pronunciation of requested word/phrase'
+  },
   bestTranslMsg: {
     uk: 'накрайщий переклад',
     en: 'best fit translation'

--- a/src/output.js
+++ b/src/output.js
@@ -10,8 +10,14 @@ const createCopyPasteActions = (word) => ({
   }
 })
 
-exports.formatMainTranslation = (translation, pronunciation, targetLang) => ({
-  title: pronunciation ? `${translation} [${pronunciation}]` : translation,
+exports.formatPronunciation = (pronunciation, targetLang) => ({
+  title: pronunciation ? `[${pronunciation}]` : '',
+  subtitle: intl.pronunciationMsg[targetLang],
+  ...createCopyPasteActions(pronunciation ?? ''),
+})
+
+exports.formatMainTranslation = (translation, targetLang) => ({
+  title: translation,
   subtitle: intl.bestTranslMsg[targetLang],
   ...createCopyPasteActions(translation),
 })

--- a/src/translate/create-translations-list.js
+++ b/src/translate/create-translations-list.js
@@ -3,22 +3,17 @@ const { addToFavoritesAction } = require('../commands/add-to-favorites.js')
 const {
   formatMainTranslation,
   formatOtherTranslations,
-  formatAutoCorrection
+  formatAutoCorrection,
+  formatPronunciation,
 } = require('../output.js')
 
 const createTranslationsList = (response, targetLang, userInput) => {
   const { text: translation, from: translationDetails, raw } = response
   const { otherTranslations, pronunciation } = parseRawResponse(raw)
 
-  const mainTranslation = formatMainTranslation(
-    translation,
-    pronunciation,
-    targetLang
-  )
-
-  const { isAutoCorrected, correctedValue } = parseAutoCorrection(
-    translationDetails
-  )
+  const requestedPhrasePronunciation = formatPronunciation(pronunciation, targetLang)
+  const mainTranslation = formatMainTranslation(translation, targetLang)
+  const { isAutoCorrected, correctedValue } = parseAutoCorrection(translationDetails)
 
   if (isAutoCorrected) {
     const suggestion = formatAutoCorrection(correctedValue, targetLang)
@@ -31,9 +26,10 @@ const createTranslationsList = (response, targetLang, userInput) => {
       targetLang
     )
     return [
-      addToFavorites,
+      (requestedPhrasePronunciation?.title ? requestedPhrasePronunciation : {}),
       mainTranslation,
-      ...formatOtherTranslations(otherTranslations)
+      ...formatOtherTranslations(otherTranslations),
+      addToFavorites,
     ]
   }
 }


### PR DESCRIPTION
### Description
Update the main translation flow items:
* **add to favorites** is moved to the end of the list
* **pronunciation** if provided goes first (this helps distinguish the best translation and requested word pronunciation)
* **best translation** goes right after the **pronunciation**

**Before**
![before](https://user-images.githubusercontent.com/6503508/209692953-5d2f1819-f4af-4bae-aed2-6d796930fa60.jpeg)

**After**
![after](https://user-images.githubusercontent.com/6503508/209692961-d5a1086c-307a-424d-8a11-c0e46d85275f.png)

### What was done
- update: main translation separated from pronunciation
- fix: align output tests accordingly to the latest changes
